### PR TITLE
WIP: Add FuseSoC support

### DIFF
--- a/src/rtl/top.v
+++ b/src/rtl/top.v
@@ -153,11 +153,13 @@ module gregdavill_serv_top(
     .clk_in          (clk),
     .data_in         (data),
     .scan_select_in  (scan_select),
+   .latch_enable_in (1'b0),
 
     // Pass all signals out from our internal scanchain, only really need data
     .clk_out         (io_out[0]),
     .data_out        (io_out[1]),
     .scan_select_out (io_out[2]),
+    .latch_enable_out (),
 
     // data
     .module_data_out ({

--- a/src/rtl/top.v
+++ b/src/rtl/top.v
@@ -143,6 +143,8 @@ module gregdavill_serv_top(
   );
 
 
+   wire	[58:0] dummy = 59'd0;
+
   scanchain_local #(
     .SCAN_LENGTH(96))
   u_scanchain_local
@@ -178,6 +180,7 @@ module gregdavill_serv_top(
       rreg1}),            // 5
 
     .module_data_in  ({
+      dummy,
       // Bus interface
       wb_mem_rdt,         // 32
       wb_mem_ack,         // 1

--- a/src/rtl/top.v
+++ b/src/rtl/top.v
@@ -133,7 +133,13 @@ module gregdavill_serv_top(
     .o_dbus_we    (wb_dbus_we),
     .o_dbus_cyc   (wb_dbus_cyc),
     .i_dbus_rdt   (wb_dbus_rdt),
-    .i_dbus_ack   (wb_dbus_ack)
+    .i_dbus_ack   (wb_dbus_ack),
+    .o_ext_funct3 (),
+    .i_ext_ready  (1'b0),
+    .i_ext_rd     (32'd0),
+    .o_ext_rs1    (),
+    .o_ext_rs2    (),
+    .o_mdu_valid  ()
   );
 
 

--- a/src/rtl/wb_mux.v
+++ b/src/rtl/wb_mux.v
@@ -24,12 +24,12 @@ module wb_mux
     output wire 	      o_wb_gpio_dat,
     output wire 	      o_wb_gpio_we,
     output wire 	      o_wb_gpio_cyc,
-    input wire 	      i_wb_gpio_rdt,
+    input wire 	      i_wb_gpio_rdt
   );
 
   parameter sim = 0;
 
-  wire  	  s = i_wb_cpu_adr[31:30];
+  wire  	  s = |i_wb_cpu_adr[31:30];
 
   assign o_wb_cpu_rdt = s ? {31'd0,i_wb_gpio_rdt} : i_wb_mem_rdt;
   always @(posedge i_clk)

--- a/src/skycells.v
+++ b/src/skycells.v
@@ -1,0 +1,47 @@
+module sky130_fd_sc_hd__buf_4
+  (
+   input wire [3:0]  A,
+   output wire [3:0] X,
+   input wire	     VPWR,
+   input wire	     VGND);
+
+  assign X = A;
+endmodule
+
+module sky130_fd_sc_hd__clkbuf_2
+  (
+   input wire  A,
+   output wire X,
+   input wire  VPWR,
+   input wire  VGND);
+
+  assign X = A;
+endmodule
+
+module sky130_fd_sc_hd__dfrtn_1
+  (input wire  RESET_B,
+   input wire CLK_N,
+   input wire D,
+   output reg Q,
+   input wire VPWR,
+   input wire VGND);
+
+   always @(negedge CLK_N)
+     Q <= D;
+
+endmodule
+
+module sky130_fd_sc_hd__sdfxtp_1
+  (
+   input wire CLK,
+   input wire D,
+   input wire SCD,
+   input wire SCE,
+   output reg Q,
+   input wire VPWR,
+   input wire VGND);
+
+   always @(posedge CLK)
+     Q <= SCE ? SCD : D;
+
+endmodule

--- a/tt02-serv.core
+++ b/tt02-serv.core
@@ -1,0 +1,24 @@
+CAPI=2:
+
+name : tt02-serv
+
+filesets:
+  rtl:
+    files:
+      - src/rtl/top.v
+      - src/rtl/scanchain.v
+      - src/rtl/wb_mux.v
+    file_type : verilogSource
+    depend : [">=::servant:1.2.0"]
+  verilator:
+    files :
+      - src/skycells.v : {file_type : verilogSource}
+
+targets:
+  lint:
+    default_tool : verilator
+    filesets : [rtl, verilator]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : gregdavill_serv_top


### PR DESCRIPTION
Adding preliminary FuseSoC support with a lint target for Verilator to begin with, and some syntax fixes for things that Verilator complained about.

I wasn't sure what to do with the latch_enable signals though, so I put that in a separate commit and set it as WIP. Also contains a workaround for a verilator issue, but I'm not sure if it's just my version that has this issue. Haven't tried a newer verilator yet